### PR TITLE
DIAN-168

### DIFF
--- a/arc/src/main/java/com/healthymedium/arc/paths/setup_v2/Setup2LoginVerificationCode.java
+++ b/arc/src/main/java/com/healthymedium/arc/paths/setup_v2/Setup2LoginVerificationCode.java
@@ -12,7 +12,9 @@ import com.healthymedium.arc.api.RestResponse;
 import com.healthymedium.arc.core.Config;
 import com.healthymedium.arc.core.LoadingDialog;
 import com.healthymedium.arc.library.R;
+import com.healthymedium.arc.navigation.NavigationManager;
 import com.healthymedium.arc.path_data.SetupPathData;
+import com.healthymedium.arc.paths.informative.ContactScreen;
 import com.healthymedium.arc.study.PathSegment;
 import com.healthymedium.arc.study.Study;
 import com.healthymedium.arc.ui.DigitView;
@@ -95,6 +97,13 @@ public class Setup2LoginVerificationCode extends Setup2Template {
     protected Setup2Template.SetupError parseForError(RestResponse response, boolean failed){
         Setup2Template.SetupError error = new Setup2Template.SetupError();
         error.string = parseForErrorString(response,failed);
+        if (error.string != null && response != null && response.errors != null) {
+            if (response.errors.get("errors") != null) {
+                error.string += "\n" + response.errors.get("errors");
+            } else if (response.errors.get("error") != null) {
+                error.string += "\n" + response.errors.get("error");
+            }
+        }
         return error;
     }
 
@@ -123,6 +132,17 @@ public class Setup2LoginVerificationCode extends Setup2Template {
     public void showError(String error) {
         textViewError.setVisibility(View.VISIBLE);
         textViewError.setText(error);
+
+        // add this for all errors
+        textViewProblems.setText(ViewUtil.getHtmlString(R.string.login_problems_linked));
+        textViewProblems.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ContactScreen contactScreen = new ContactScreen();
+                NavigationManager.getInstance().open(contactScreen);
+            }
+        });
+        textViewProblems.setVisibility(View.VISIBLE);
     }
 
     public void hideError(){

--- a/sage/src/main/java/org/sagebionetworks/SageRestApi.kt
+++ b/sage/src/main/java/org/sagebionetworks/SageRestApi.kt
@@ -492,11 +492,6 @@ open class SageRestApi(val reportManager: ParticipantRecordManager,
     private fun parseWakeSleepSchedule(json: String?, data: ExistingData): String? {
         try {
             val wakeSleep = gson.fromJson(json, WakeSleepSchedule::class.java)
-            // Data validation check, if we had a JSON string, but could not parse into a model
-            // object, then we know that the JSON is in an invalid format, and we should notify the user.
-            if (wakeSleep == null && (json?.isNotEmpty() == true)) {
-                return "WakeSleep invalid data format"
-            }
             data.wake_sleep_schedule = wakeSleep
         } catch (e: JsonSyntaxException) {
             return "WakeSleep invalid data format"
@@ -507,12 +502,6 @@ open class SageRestApi(val reportManager: ParticipantRecordManager,
     private fun parseTestSchedule(json: String?, data: ExistingData): String? {
         try {
             val schedule = gson.fromJson(json, TestSchedule::class.java)
-
-            // Data validation check, if we had a JSON string, but could not parse into a model
-            // object, then we know that the JSON is in an invalid format, and we should notify the user.
-            if (schedule == null && (json?.isNotEmpty() == true)) {
-                return "TestSchedule invalid data format"
-            }
 
             data.test_schedule = schedule
 
@@ -538,13 +527,6 @@ open class SageRestApi(val reportManager: ParticipantRecordManager,
     private fun parseCompletedTests(json: String?, data: ExistingData): String? {
         try {
             val completed = gson.fromJson(json, CompletedTestList::class.java)
-
-            // Data validation check, if we had a JSON string, but could not parse into a model
-            // object, then we know that the JSON is in an invalid format, and we should notify the user.
-            if (completed == null && (json?.isNotEmpty() == true)) {
-                return "CompletedTestList invalid data format"
-            }
-
             completedTestManager.setCurrentList(completed ?: CompletedTestList(listOf()))
             earningsController.completedTests = completedTestManager.current.completed
         } catch (e: JsonSyntaxException) {


### PR DESCRIPTION
Sarah S signed in with an account that was originally created on Android and had some missing JSON fields required on iOS.  It ended up treating the failed JSON parsing as OK and let her restart the study, which cleared out the data on the account.  That is not desired, as it should show an error message to the user, keep their data, and then we can fix it on the back-end.  This PR accomplishes that.