### PR TITLE
PasswordGeneratorBugFix

### DIFF
--- a/sage/src/main/java/org/sagebionetworks/migration/PasswordGenerator.java
+++ b/sage/src/main/java/org/sagebionetworks/migration/PasswordGenerator.java
@@ -36,6 +36,7 @@ import com.google.common.collect.Sets;
 
 import java.security.SecureRandom;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class PasswordGenerator {
@@ -92,7 +93,7 @@ public class PasswordGenerator {
     }
 
     private Set<Integer> getFourUniqueIntegers(int max) {
-        Set<Integer> set = Sets.newHashSetWithExpectedSize(4);
+        LinkedHashSet<Integer> set = new LinkedHashSet<>(4);
         while (set.size() < 4) {
             set.add(RANDOM.nextInt(max));
         }

--- a/sage/src/test/java/org/sagebionetoworks/migration/PasswordGeneratorTests.java
+++ b/sage/src/test/java/org/sagebionetoworks/migration/PasswordGeneratorTests.java
@@ -35,6 +35,8 @@ import org.junit.Test;
 import org.sagebionetworks.migration.PasswordGenerator;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -44,11 +46,29 @@ public class PasswordGeneratorTests {
     @Test
     public void test_createBridgePassword() throws IOException {
         // Test 10000 bridge passwords for validity
+        Map<Integer, Integer> counts = new HashMap<>();
+        for (int i = 0; i < 9; i++) {
+            counts.put(i, 0);
+        }
+
         for (int i = 0; i < 10000; i++) {
             String password = PasswordGenerator.INSTANCE.nextPassword();
             assertNotNull(password);
             assertEquals(9, password.length());
             assertTrue(isValidBridgePassword(password));
+
+            // Add to the counts of where each symbol is
+            for (int j = 0; j < PasswordGenerator.SYMBOLIC.length(); j++) {
+                int symbolIdx =  password.indexOf(PasswordGenerator.SYMBOLIC.charAt(j));
+                if (symbolIdx >= 0) {
+                    counts.put(symbolIdx, counts.get(symbolIdx) + 1);
+                }
+            }
+        }
+
+        for (int i = 0; i < 9; i++) {
+            // Make sure that the distribution has at least 1% of the distribution
+            assertTrue(counts.get(i) > 10);
         }
     }
 


### PR DESCRIPTION
I noticed that the passwords that were generated from the code Alx gave me heavily favored the symbol being in the 6th or 7th character location. I thought that was odd, so I investigated deeper using the code in the screenshot below, and found that the distribution never put the symbol at index 0 and 1, which made me realize there was definitely a bug somewhere.

<img width="774" alt="Screen Shot 2021-11-16 at 3 37 04 PM" src="https://user-images.githubusercontent.com/5590748/142092180-3dd985ea-9cb5-4bab-a12e-40b0fee8abdc.png">

The root cause of the bug ended up being that the getFourUniqueIntegers function stores the random ints in a HashSet which orders the values from lowest to highest. So, when the nextPassword function converts it to an iterator, the symbols always gets the highest value of the set, which explains why 0 and 1 are not possible.

I switched to using a LinkedHashSet which stores the Ints based on the order you added them instead of what the value of them in the set is. This fixed the bug.

I added a conditional check in the unit tests that the symbol must be placed in each index at least 1% of the time for the tests to pass. The old algorithm failed the test, but the new one passes every time.